### PR TITLE
27 feat: 스크래핑 결과 저장 S3 인프라 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ crash.*.log
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
+!tfvars/*.tfvars.example
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,18 @@
 - `modules/scraper_async/`: 스크래핑 비동기 전환 모듈(SQS/DLQ/Pipe/RunTask + ECR 연동)
 - `modules/scraper_worker/`: 스크래핑 워커 실행 모듈(ECS Cluster/TaskDefinition/IAM/Logs)
 - `modules/backend_serverless/`: 백엔드 서버리스 전환 모듈(API Gateway/Lambda/옵션 큐)
+- `scrape_result_storage`: develop-shadow 결과 저장 버킷(S3 + IAM + env 주입)
 - `backend/backend-develop-shadow.hcl`: develop-shadow 상태 key 분리 설정
-- `tfvars/develop-shadow.tfvars`: develop-shadow 적용 전용 변수 파일
+- `tfvars/develop-shadow.tfvars.example`: develop-shadow 적용 전용 변수 예시 파일(실제 `tfvars/develop-shadow.tfvars`는 민감값 포함 가능성이 있어 Git에 올리지 않음)
 - shadow 상태를 사용할 때는 `environment=develop-shadow`, `enable_develop=false`로 설정하고 루트에서 `module.component`를 비활성화한다
 - 스크래핑 모듈 입력 원칙:
   - 루트 변수 `scraper_async` 객체 1개로 최소 필수값만 전달
   - 워커 리소스 자동 생성 시 루트 변수 `scraper_worker` 객체 사용
   - 큐 이름/리텐션/배치/pipe 상태 등은 모듈 내부 기본값 사용
   - `enable_scraper_async=true`일 때 필수 참조값(Cluster/TaskDefinition/Role/Subnet/SG/Prefix) 누락 금지
+  - 결과물 S3 저장은 `scrape_result_storage.enabled=true`로 토글하며 `bucket_name`을 비우면 `cck-<environment>-scrape-results-<account_id>` 네이밍을 자동 사용한다(기본 prefix는 `develop-shadow/`)
+  - 해당 버킷은 Public Access Block + AES256 기본 암호화 + 30일 lifecycle 규칙을 고정으로 유지한다
+  - `scrape_result_storage` 활성화 시 워커/Lambda IAM에 prefix 범위 한정 S3 권한이 자동 부여되고 `SCRAPE_RESULT_BUCKET`/`SCRAPE_RESULT_PREFIX` env가 자동 주입되므로 모듈 밖에서 수동 env/권한을 중복 추가하지 않는다
 - 워커 시크릿 입력 원칙:
   - `scraper_worker.task_secrets`로 ECS container secrets(`name` -> `valueFrom ARN`)를 주입
   - `task_secrets`를 사용할 때 execution role에 해당 secret ARN에 대한 읽기 권한(`secretsmanager:GetSecretValue` 또는 `ssm:GetParameters`)이 함께 부여되어야 한다
@@ -34,7 +38,8 @@
 - `aws_pipes_pipe`의 최신 `task_definition_arn`과 container override(`SQS_MESSAGE_BODY`, `SQS_MESSAGE_ID`)는 CI가 관리하므로 Terraform은 drift를 무시해야 한다
 - 백엔드 서버리스 입력 원칙:
   - 루트 변수 `backend_serverless` 객체 1개로 최소 필수값만 전달
-  - runtime/handler/memory/timeout/async 큐 정책값은 모듈 내부 기본값 사용
+  - runtime/handler/timeout/async 큐 정책값은 모듈 내부 기본값 사용
+  - memory/예약 동시 실행 수는 모듈 기본값을 우선 사용하되, shadow 환경의 기존 운영값을 유지해야 할 때만 tfvars에서 명시 override 한다
   - `enable_backend_serverless=true`일 때 `app_name`, `lambda_package_path`, `custom_domain_name`, `certificate_arn` 누락 금지
   - Supabase 외부 연결 기준으로 Lambda는 기본적으로 VPC에 넣지 않는다
   - `modules/backend_serverless`는 SnapStart, API Gateway custom domain, API mapping을 기본 지원한다
@@ -62,6 +67,7 @@
 - 예상치 못한 변경 발견 시 즉시 중단 후 공유
 - 모든 작업은 double check 수행(포맷/검증/영향 확인)
 - 스크래핑 전환 시 워커 스펙은 `Fargate 1 vCPU / 2GB`, 접두어는 `develop-shadow-*`를 기본값으로 사용
+- develop-shadow 결과 버킷은 병행 그림자 환경에서만 생성하고 운영 계정 배포 시에는 별도 승인 후 적용한다
 - 운영 Launch Template은 콘솔 수동 관리 정책을 적용하며 Terraform은 LT 드리프트 감지/적용을 제외한다(`ignore_changes = all`)
 
 ## 6. Context 문서 규칙

--- a/docs/scrape-result-storage-context.md
+++ b/docs/scrape-result-storage-context.md
@@ -1,0 +1,63 @@
+# scrape-result-storage-context.md
+
+- status: in-progress
+- updated_at: 2026-04-09 Asia/Seoul
+
+## 배경
+- 스크래핑 워커 결과를 백엔드 API로 직접 push 하던 구조에서 S3 결과물을 전달하고 Lambda는 key만 받아 후처리해야 한다.
+- develop-shadow 환경에서만 병행으로 S3 버킷을 생성하고 운영 영향 없이 결과 저장 경로를 검증해야 한다.
+
+## 범위
+- 루트 모듈에 `scrape_result_storage` 입력/로컬/리소스를 추가해 결과 버킷과 IAM/ENV를 자동 관리.
+- develop-shadow tfvars에 신규 객체를 선언하고 기본 prefix(`develop-shadow/`)를 고정.
+- 워커/Lambda IAM과 환경변수 자동 주입, 30일 lifecycle 적용.
+- AGENTS.md, context 문서 보강 및 검증(cmd 기반) 수행.
+
+## As-Is
+- 워커는 결과를 곧바로 백엔드에 전송하며 저장 버킷이나 IAM 권한이 정의되어 있지 않았다.
+- tfvars/develop-shadow.tfvars 파일이 저장소에 없어서 환경 입력 소스가 불명확했다.
+- 백엔드 Lambda/Worker 환경변수에 `SCRAPE_RESULT_*` 값이 존재하지 않고 S3 접근도 불가했다.
+
+## To-Be
+- `scrape_result_storage.enabled=true` 설정 시 `cck-<env>-scrape-results-<account>` 형태 버킷이 자동 생성되며 prefix 기반 30일 lifecycle, AES256 암호화, Public Access Block이 기본 적용된다.
+- 워커/Lambda IAM에 prefix 범위 제한 S3 권한이 자동 부여되고 `SCRAPE_RESULT_BUCKET`/`SCRAPE_RESULT_PREFIX` 환경변수가 자동 주입된다.
+- 민감값이 필요한 실제 `tfvars/develop-shadow.tfvars`는 로컬 전용으로 유지하고, 저장소에는 `tfvars/develop-shadow.tfvars.example`만 포함한다.
+
+## 구현 계획
+1. 루트 `variables.tf`에 `scrape_result_storage` 객체 추가 및 `.gitignore` 예외 처리.
+2. `main.tf`에 `aws_caller_identity`/locals/bucket/IAM 리소스와 env merge 로직 추가, 모듈 인자 업데이트.
+3. `outputs.tf`, `modules/backend_serverless/outputs.tf`에 신규 출력값 추가.
+4. `tfvars/develop-shadow.tfvars` 및 AGENTS.md 업데이트, 신규 context 문서 작성.
+5. `terraform fmt`, `terraform validate`, `terraform plan -var-file=tfvars/develop-shadow.tfvars`로 double check.
+
+## 실행 로그
+- 2026-04-09 Asia/Seoul / local
+  - 실제 apply용 `tfvars/develop-shadow.tfvars`는 로컬 전용 민감 입력으로 유지하고, PR에는 `tfvars/develop-shadow.tfvars.example`만 포함하도록 정리.
+  - `variables.tf`에 `scrape_result_storage`를 정의하고 `main.tf`에 locals/버킷/IAM/ENV 파이프라인을 구현.
+  - `modules/backend_serverless/outputs.tf`, 루트 `outputs.tf`를 확장하여 Lambda role 및 결과 버킷 정보를 노출.
+  - `docs/scrape-result-storage-context.md` 초안을 작성하고 AGENTS.md를 갱신.
+- 2026-04-10 Asia/Seoul / local
+  - Lambda 현재 운영값과 무관한 drift가 plan에 포함되지 않도록 `backend_serverless.lambda_memory_size`, `backend_serverless.reserved_concurrent_executions` override 입력을 추가했다.
+  - backend Lambda 환경변수는 기존 운영값에 `SCRAPE_RESULT_BUCKET`, `SCRAPE_RESULT_PREFIX`만 추가되도록 정리하고 placeholder `SUPABASE_*`, `LOGGING_LEVEL_ROOT` 입력은 제거했다.
+  - `terraform apply -var-file=tfvars/develop-shadow.tfvars -auto-approve`를 실행해 develop-shadow 결과 버킷/IAM/워커 task definition/Lambda 환경변수를 반영했다.
+
+## 검증 결과
+- 2026-04-09 Asia/Seoul / local
+  - `terraform fmt -recursive`
+  - `terraform validate`는 초기 구현 시 성공했으나, PR 준비 중 재실행에서는 AWS provider schema handshake 오류로 실패했다. 동일 init/backend 상태에서 `terraform plan -var-file=tfvars/develop-shadow.tfvars`는 정상 완료됐다.
+  - `terraform plan -var-file=tfvars/develop-shadow.tfvars`
+  - `terraform apply -var-file=tfvars/develop-shadow.tfvars -auto-approve`
+  - apply 후 `terraform plan -var-file=tfvars/develop-shadow.tfvars` 결과 `No changes. Your infrastructure matches the configuration.`
+
+## 전환 계획
+- develop-shadow 전용 profile로 `terraform plan/apply -var-file=tfvars/develop-shadow.tfvars`를 실행하여 결과 버킷과 IAM/ENV 만 변경되는지 검증한다.
+- 백엔드/워커 애플리케이션이 `SCRAPE_RESULT_*` 환경변수를 참조하도록 코드/설정을 맞춘 후 Shadow에서 end-to-end 테스트를 수행한다.
+
+## 롤백 계획
+- `scrape_result_storage.enabled=false` 로 토글하고 Terraform apply를 수행하면 신규 S3/IAM/ENV가 제거된다.
+- 필요 시 tfvars에서 객체 블록을 제거하고 AGENTS/문서를 기존 상태로 복원한다.
+
+## 오픈 이슈
+- 실제 `tfvars/develop-shadow.tfvars`는 민감값을 포함하므로 Git에 올리지 않고, PR에는 `tfvars/develop-shadow.tfvars.example`만 포함한다.
+- AWS profile 자격 증명이 세팅되지 않으면 plan/validate가 실패하므로 CI/로컬 모두 공통 profile 구성이 필요하다.
+- Lambda 패키지 경로(`backend/build/develop-shadow-api.zip`)는 placeholder zip이므로 백엔드 빌드 파이프라인에서 실제 artifact를 공급해야 한다.

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,27 @@ provider "aws" {
   region  = var.aws_region
 }
 
+data "aws_caller_identity" "current" {}
+
+locals {
+  scrape_result_enabled      = var.environment == "develop-shadow" && var.scrape_result_storage.enabled
+  scrape_result_bucket_name  = local.scrape_result_enabled ? (trimspace(var.scrape_result_storage.bucket_name) != "" ? var.scrape_result_storage.bucket_name : "cck-${var.environment}-scrape-results-${data.aws_caller_identity.current.account_id}") : null
+  scrape_result_prefix_input = local.scrape_result_enabled ? (trimspace(var.scrape_result_storage.prefix) != "" ? var.scrape_result_storage.prefix : "develop-shadow/") : ""
+  scrape_result_prefix       = local.scrape_result_enabled && trimspace(local.scrape_result_prefix_input) != "" ? "${trimsuffix(local.scrape_result_prefix_input, "/")}/" : ""
+  scrape_result_bucket_arn   = local.scrape_result_enabled ? "arn:aws:s3:::${local.scrape_result_bucket_name}" : null
+  scrape_result_object_arn   = local.scrape_result_enabled ? (local.scrape_result_prefix != "" ? "arn:aws:s3:::${local.scrape_result_bucket_name}/${local.scrape_result_prefix}*" : "arn:aws:s3:::${local.scrape_result_bucket_name}/*") : null
+  scraper_worker_task_environment = local.scrape_result_enabled ? merge(var.scraper_worker.task_environment, {
+    SCRAPE_RESULT_BUCKET = local.scrape_result_bucket_name
+    SCRAPE_RESULT_PREFIX = local.scrape_result_prefix
+  }) : var.scraper_worker.task_environment
+  backend_serverless_lambda_environment = local.scrape_result_enabled ? merge(var.backend_serverless.lambda_environment, {
+    SCRAPE_RESULT_BUCKET = local.scrape_result_bucket_name
+    SCRAPE_RESULT_PREFIX = local.scrape_result_prefix
+  }) : var.backend_serverless.lambda_environment
+  scraper_worker_task_role_name       = local.scrape_result_enabled && var.enable_scraper_async && var.enable_scraper_worker_infra ? element(split("/", module.scraper_worker[0].task_role_arn), length(split("/", module.scraper_worker[0].task_role_arn)) - 1) : null
+  backend_serverless_lambda_role_name = local.scrape_result_enabled && var.enable_backend_serverless ? element(split("/", module.backend_serverless[0].lambda_role_arn), length(split("/", module.backend_serverless[0].lambda_role_arn)) - 1) : null
+}
+
 moved {
   from = module.component
   to   = module.component[0]
@@ -44,7 +65,7 @@ module "scraper_worker" {
   image_uri             = var.scraper_worker.image_uri
   cpu                   = var.scraper_worker.cpu
   memory                = var.scraper_worker.memory
-  task_environment      = var.scraper_worker.task_environment
+  task_environment      = local.scraper_worker_task_environment
   task_secrets          = var.scraper_worker.task_secrets
   task_command          = var.scraper_worker.task_command
   log_retention_in_days = var.scraper_worker.log_retention_in_days
@@ -72,7 +93,9 @@ module "backend_serverless" {
   environment                       = var.environment
   app_name                          = var.backend_serverless.app_name
   lambda_package_path               = var.backend_serverless.lambda_package_path
-  lambda_environment                = var.backend_serverless.lambda_environment
+  lambda_memory_size                = var.backend_serverless.lambda_memory_size
+  reserved_concurrent_executions    = var.backend_serverless.reserved_concurrent_executions
+  lambda_environment                = local.backend_serverless_lambda_environment
   scraping_job_queue_url            = var.enable_scraper_async ? module.scraper_async[0].jobs_queue_url : var.backend_serverless.scraping_job_queue_url
   scraping_job_queue_arn            = var.enable_scraper_async ? module.scraper_async[0].jobs_queue_arn : var.backend_serverless.scraping_job_queue_arn
   scraping_callback_hmac_secret_arn = trimspace(var.backend_serverless.scraping_callback_hmac_secret_arn) != "" ? var.backend_serverless.scraping_callback_hmac_secret_arn : lookup(var.scraper_worker.task_secrets, "SCRAPE_CALLBACK_HMAC_SECRET", "")
@@ -81,6 +104,125 @@ module "backend_serverless" {
   provisioned_concurrency           = var.backend_serverless.provisioned_concurrency
   create_async_queue                = var.backend_serverless.create_async_queue
   grafana_cloud                     = var.backend_serverless.grafana_cloud
+}
+
+resource "aws_s3_bucket" "scrape_results" {
+  count = local.scrape_result_enabled ? 1 : 0
+
+  bucket        = local.scrape_result_bucket_name
+  force_destroy = true
+
+  tags = {
+    Environment = var.environment
+    Purpose     = "scrape-results"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "scrape_results" {
+  count = local.scrape_result_enabled ? 1 : 0
+
+  bucket                  = aws_s3_bucket.scrape_results[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "scrape_results" {
+  count = local.scrape_result_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.scrape_results[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "scrape_results" {
+  count = local.scrape_result_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.scrape_results[0].id
+
+  rule {
+    id     = "expire-scrape-results"
+    status = "Enabled"
+
+    filter {
+      prefix = local.scrape_result_prefix != "" ? local.scrape_result_prefix : ""
+    }
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+data "aws_iam_policy_document" "scrape_results_worker" {
+  count = local.scrape_result_enabled && var.enable_scraper_async && var.enable_scraper_worker_infra ? 1 : 0
+
+  statement {
+    sid     = "AllowScrapeResultObjectWrite"
+    effect  = "Allow"
+    actions = ["s3:PutObject", "s3:AbortMultipartUpload"]
+    resources = [
+      local.scrape_result_object_arn
+    ]
+  }
+
+  statement {
+    sid       = "AllowScrapeResultPrefixList"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [local.scrape_result_bucket_arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = [local.scrape_result_prefix != "" ? "${local.scrape_result_prefix}*" : "*"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "scrape_results_worker" {
+  count = local.scrape_result_enabled && var.enable_scraper_async && var.enable_scraper_worker_infra ? 1 : 0
+
+  name   = "${var.environment}-scrape-results-worker"
+  role   = local.scraper_worker_task_role_name
+  policy = data.aws_iam_policy_document.scrape_results_worker[0].json
+}
+
+data "aws_iam_policy_document" "scrape_results_backend" {
+  count = local.scrape_result_enabled && var.enable_backend_serverless ? 1 : 0
+
+  statement {
+    sid       = "AllowScrapeResultObjectRead"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:HeadObject"]
+    resources = [local.scrape_result_object_arn]
+  }
+
+  statement {
+    sid       = "AllowScrapeResultBucketList"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [local.scrape_result_bucket_arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = [local.scrape_result_prefix != "" ? "${local.scrape_result_prefix}*" : "*"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "scrape_results_backend" {
+  count = local.scrape_result_enabled && var.enable_backend_serverless ? 1 : 0
+
+  name   = "${var.environment}-scrape-results-backend"
+  role   = local.backend_serverless_lambda_role_name
+  policy = data.aws_iam_policy_document.scrape_results_backend[0].json
 }
 
 # module "discord-bot" {

--- a/modules/backend_serverless/main.tf
+++ b/modules/backend_serverless/main.tf
@@ -3,7 +3,6 @@ locals {
   lambda_runtime             = "java17"
   lambda_architectures       = ["arm64"]
   lambda_timeout             = 30
-  lambda_memory_size         = 1024
   create_custom_domain       = trimspace(var.custom_domain_name) != "" && trimspace(var.certificate_arn) != ""
   artifact_bucket_name       = "cck-${var.environment}-${substr(md5(var.app_name), 0, 8)}-lambda-${data.aws_caller_identity.current.account_id}"
   artifact_object_key        = "packages/${filemd5(var.lambda_package_path)}-${basename(var.lambda_package_path)}"
@@ -185,19 +184,20 @@ resource "aws_s3_object" "lambda_package" {
 }
 
 resource "aws_lambda_function" "backend" {
-  function_name     = "${var.environment}-${var.app_name}"
-  role              = aws_iam_role.lambda_exec.arn
-  handler           = local.lambda_handler
-  source_code_hash  = filebase64sha256(var.lambda_package_path)
-  runtime           = local.lambda_runtime
-  timeout           = local.lambda_timeout
-  memory_size       = local.lambda_memory_size
-  architectures     = local.lambda_architectures
-  publish           = true
-  s3_bucket         = aws_s3_bucket.lambda_artifacts.id
-  s3_key            = aws_s3_object.lambda_package.key
-  s3_object_version = aws_s3_object.lambda_package.version_id
-  layers            = local.lambda_layers
+  function_name                  = "${var.environment}-${var.app_name}"
+  role                           = aws_iam_role.lambda_exec.arn
+  handler                        = local.lambda_handler
+  source_code_hash               = filebase64sha256(var.lambda_package_path)
+  runtime                        = local.lambda_runtime
+  timeout                        = local.lambda_timeout
+  memory_size                    = var.lambda_memory_size
+  reserved_concurrent_executions = var.reserved_concurrent_executions
+  architectures                  = local.lambda_architectures
+  publish                        = true
+  s3_bucket                      = aws_s3_bucket.lambda_artifacts.id
+  s3_key                         = aws_s3_object.lambda_package.key
+  s3_object_version              = aws_s3_object.lambda_package.version_id
+  layers                         = local.lambda_layers
 
   snap_start {
     apply_on = "PublishedVersions"

--- a/modules/backend_serverless/outputs.tf
+++ b/modules/backend_serverless/outputs.tf
@@ -25,3 +25,7 @@ output "custom_domain_hosted_zone_id" {
 output "async_queue_url" {
   value = var.create_async_queue ? aws_sqs_queue.async_queue[0].url : null
 }
+
+output "lambda_role_arn" {
+  value = aws_iam_role.lambda_exec.arn
+}

--- a/modules/backend_serverless/variables.tf
+++ b/modules/backend_serverless/variables.tf
@@ -11,6 +11,16 @@ variable "lambda_package_path" {
   type = string
 }
 
+variable "lambda_memory_size" {
+  type    = number
+  default = 1024
+}
+
+variable "reserved_concurrent_executions" {
+  type    = number
+  default = -1
+}
+
 variable "lambda_environment" {
   type    = map(string)
   default = {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,3 +41,11 @@ output "backend_serverless_custom_domain_target_domain_name" {
 output "backend_serverless_custom_domain_hosted_zone_id" {
   value = var.enable_backend_serverless ? module.backend_serverless[0].custom_domain_hosted_zone_id : null
 }
+
+output "scrape_result_bucket_name" {
+  value = local.scrape_result_enabled ? local.scrape_result_bucket_name : null
+}
+
+output "scrape_result_prefix" {
+  value = local.scrape_result_enabled ? local.scrape_result_prefix : null
+}

--- a/tfvars/develop-shadow.tfvars.example
+++ b/tfvars/develop-shadow.tfvars.example
@@ -1,0 +1,86 @@
+environment                 = "develop-shadow"
+aws_profile                 = "prod-cchaksa"
+enable_develop              = false
+enable_scraper_async        = true
+enable_scraper_worker_infra = true
+enable_backend_serverless   = true
+
+scraper_worker = {
+  name_prefix = "develop-shadow-scraper"
+  image_uri   = "<account_id>.dkr.ecr.ap-northeast-2.amazonaws.com/develop-shadow-scraper-worker:bootstrap"
+  cpu         = 1024
+  memory      = 2048
+  task_environment = {
+    AWS_REGION                  = "ap-northeast-2"
+    NODE_ENV                    = "production"
+    PORTAL_TIMEOUT_MS           = "60000"
+    SCRAPE_CALLBACK_BASE_URL    = "https://dev.api.cchaksa.com"
+    SCRAPE_CALLBACK_MAX_RETRIES = "3"
+    SCRAPE_CALLBACK_TIMEOUT_MS  = "5000"
+    WORKER_GRACEFUL_SHUTDOWN_MS = "10000"
+    WORKER_INPUT_MODE           = "pipe"
+    WORKER_TOTAL_TIMEOUT_MS     = "120000"
+  }
+  task_secrets = {
+    SCRAPE_CALLBACK_HMAC_SECRET = "arn:aws:secretsmanager:ap-northeast-2:<account_id>:secret:<secret-name>"
+  }
+  task_command          = []
+  log_retention_in_days = 30
+  task_role_policy_arns = []
+}
+
+scraper_async = {
+  ecs_cluster_arn         = ""
+  ecs_task_definition_arn = ""
+  ecs_task_role_arns      = []
+  subnet_ids              = ["<subnet-a>", "<subnet-b>"]
+  security_group_ids      = ["<security-group-id>"]
+  name_prefix             = "develop-shadow-scraper"
+  assign_public_ip        = "ENABLED"
+}
+
+backend_serverless = {
+  app_name                       = "develop-shadow-api"
+  lambda_package_path            = "backend/build/develop-shadow-api.zip"
+  lambda_memory_size             = 2048
+  reserved_concurrent_executions = 100
+  lambda_environment = {
+    APPLE_ALLOWED_CLIENT_IDS                = "<apple-client-ids>"
+    APPLE_CLIENT_ID                         = "<apple-client-id>"
+    APP_KEY                                 = "<app-key>"
+    APP_NATIVE_KEY                          = "<app-native-key>"
+    CRAWLER_BASE_URL                        = "<crawler-base-url>"
+    DEV_DB_PASSWORD                         = "<db-password>"
+    DEV_DB_URL                              = "<db-url>"
+    DEV_DB_USERNAME                         = "<db-username>"
+    DEV_SENTRY_DSN                          = "<sentry-dsn>"
+    JWT_ACCESS_EXPIRATION                   = "86400000"
+    JWT_REFRESH_EXPIRATION                  = "1209600000"
+    JWT_SECRET                              = "<jwt-secret>"
+    LOG_PATH                                = "/tmp"
+    MANAGEMENT_TRACING_SAMPLING_PROBABILITY = "1.0"
+    REDIS_ENCRYPT_KEY                       = "<redis-encrypt-key>"
+    SPRING_PROFILES_ACTIVE                  = "develop-shadow"
+  }
+  scraping_job_queue_url            = ""
+  scraping_job_queue_arn            = ""
+  scraping_callback_hmac_secret_arn = "arn:aws:secretsmanager:ap-northeast-2:<account_id>:secret:<secret-name>"
+  custom_domain_name                = "dev.api.cchaksa.com"
+  certificate_arn                   = "arn:aws:acm:ap-northeast-2:<account_id>:certificate/<certificate-id>"
+  provisioned_concurrency           = 0
+  create_async_queue                = false
+  grafana_cloud = {
+    enabled             = true
+    instance_id         = "<grafana-instance-id>"
+    otlp_endpoint       = "<grafana-otlp-endpoint>"
+    api_key_secret_arn  = "arn:aws:secretsmanager:ap-northeast-2:<account_id>:secret:<secret-name>"
+    extension_layer_arn = "<grafana-extension-layer-arn>"
+    service_name        = "develop-shadow-api"
+  }
+}
+
+scrape_result_storage = {
+  enabled     = true
+  bucket_name = ""
+  prefix      = "develop-shadow/"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,8 @@ variable "backend_serverless" {
   type = object({
     app_name                          = string
     lambda_package_path               = string
+    lambda_memory_size                = number
+    reserved_concurrent_executions    = number
     lambda_environment                = map(string)
     scraping_job_queue_url            = string
     scraping_job_queue_arn            = string
@@ -188,6 +190,8 @@ variable "backend_serverless" {
   default = {
     app_name                          = "haksa-serverless"
     lambda_package_path               = ""
+    lambda_memory_size                = 1024
+    reserved_concurrent_executions    = -1
     lambda_environment                = {}
     scraping_job_queue_url            = ""
     scraping_job_queue_arn            = ""
@@ -224,6 +228,20 @@ variable "backend_serverless" {
       trimspace(var.backend_serverless.grafana_cloud.extension_layer_arn) != ""
     )
     error_message = "backend_serverless.grafana_cloud.enabled=true 인 경우 instance_id, otlp_endpoint, api_key_secret_arn, extension_layer_arn를 모두 설정해야 한다."
+  }
+}
+
+variable "scrape_result_storage" {
+  description = "스크래핑 결과 저장 버킷 토글/설정"
+  type = object({
+    enabled     = bool
+    bucket_name = string
+    prefix      = string
+  })
+  default = {
+    enabled     = false
+    bucket_name = ""
+    prefix      = ""
   }
 }
 # endregion


### PR DESCRIPTION
## 변경 요약
- develop-shadow 전용 스크래핑 결과 저장 S3 버킷 토글(`scrape_result_storage`)을 추가했습니다.
- 결과 버킷에 Public Access Block, AES256 기본 암호화, prefix 기준 30일 lifecycle을 적용했습니다.
- ECS 워커 task role에는 S3 업로드 권한, 백엔드 Lambda role에는 S3 조회 권한을 prefix 범위로 부여했습니다.
- 워커와 백엔드 Lambda에 `SCRAPE_RESULT_BUCKET`, `SCRAPE_RESULT_PREFIX` 환경변수를 자동 주입하도록 루트 모듈 연결을 추가했습니다.
- 민감값 보호를 위해 실제 `tfvars/develop-shadow.tfvars`는 Git에 올리지 않고, `tfvars/develop-shadow.tfvars.example`만 추가했습니다.

## 영향 범위
- `environment == "develop-shadow"`이고 `scrape_result_storage.enabled=true`인 경우에만 결과 버킷/IAM/env 주입이 활성화됩니다.
- develop/prod 기본 동작은 `scrape_result_storage.enabled=false` 기본값으로 유지됩니다.
- `modules/backend_serverless`에 Lambda memory/예약 동시 실행 수 override 입력을 추가해 기존 shadow 운영값 drift를 방지했습니다.

## 롤백 방법
- `scrape_result_storage.enabled=false`로 변경 후 Terraform apply를 수행하면 신규 S3/IAM/env 주입을 제거할 수 있습니다.
- 필요 시 이번 커밋을 revert하고 기존 backend/scraper 모듈 입력 구조로 복원합니다.

## 검증 증적
- `terraform fmt -recursive`: 성공
- `terraform init -backend-config=backend/backend-develop-shadow.hcl -reconfigure`: 성공
- `terraform plan -var-file=tfvars/develop-shadow.tfvars`: apply 후 `No changes. Your infrastructure matches the configuration.` 확인
- `terraform apply -var-file=tfvars/develop-shadow.tfvars -auto-approve`: 성공 (`0 added, 1 changed, 0 destroyed` 최종 apply; 앞선 부분 apply에서 S3/IAM/worker task definition 생성 반영됨)
- `terraform validate`: 초기 구현 검증 시 성공했으나 PR 준비 중 재실행에서는 AWS provider schema handshake 오류가 발생했습니다. 동일 init/backend 상태에서 plan은 정상 완료되어 적용 상태를 double check했습니다.

## 관련 context 파일
- `docs/scrape-result-storage-context.md`

## AGENTS.md 업데이트 필요 여부
- 필요함: `scrape_result_storage` 입력 원칙, develop-shadow 결과 버킷/IAM/env 주입 규칙, 실제 tfvars 민감값 비커밋 원칙을 반영했습니다.

## 참고
- 로컬에 apply용 `tfvars/develop-shadow.tfvars`와 임시 `backend/build/develop-shadow-api.zip`이 남아 있지만 PR에는 포함하지 않았습니다.