### PR TITLE
30 feat: EventBridge maintenance 스케줄러 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,10 @@
   - `modules/backend_serverless`는 SnapStart, API Gateway custom domain, API mapping을 기본 지원한다
   - Lambda 패키지가 직접 업로드 한도를 넘는 경우를 대비해 `modules/backend_serverless`는 전용 S3 artifact bucket/object를 통해 배포한다
   - Lambda Grafana Cloud 연동은 `backend_serverless.grafana_cloud` 객체로 관리하며 extension layer ARN, instance ID, OTLP endpoint, API key secret ARN을 함께 전달한다
+  - Lambda maintenance 작업 전환은 `backend_serverless.maintenance_schedules` 객체로 관리하며 EventBridge Scheduler가 `live` alias를 직접 invoke한다
   - Grafana Cloud API key는 코드/평문 tfvars에 두지 않고 Secrets Manager ARN으로만 주입하며, Lambda role에는 `secretsmanager:GetSecretValue` 권한을 부여한다
   - 스크래핑 비동기 백엔드 연동 시 `SCRAPING_JOB_QUEUE_URL`은 스크래핑 모듈 출력값을 우선 사용하고, Lambda role에는 대상 큐에 대한 `sqs:SendMessage/GetQueueAttributes/GetQueueUrl` 권한이 함께 부여되어야 한다
+  - S3 기반 스크래핑 결과 저장소는 루트 변수 `scrape_result_storage`로 관리하고, bucket/prefix/timeout 환경변수는 백엔드 Lambda와 scraper worker에 공통 주입한다
   - `SCRAPING_CALLBACK_HMAC_SECRET`은 코드 저장소에 평문으로 두지 않고 Secrets Manager ARN을 통해 Lambda 환경변수로 주입한다
   - `develop-shadow` 백엔드 Lambda 코드는 백엔드 저장소 CI가 배포하므로 Terraform은 `aws_s3_object.lambda_package`, `aws_lambda_function.backend`의 코드 관련 속성, `aws_lambda_alias.live.function_version` 드리프트를 무시하고 인프라/환경변수만 관리한다
 

--- a/docs/eventbridge-maintenance-scheduler-context.md
+++ b/docs/eventbridge-maintenance-scheduler-context.md
@@ -1,0 +1,33 @@
+# eventbridge-maintenance-scheduler-context.md
+
+- status: in-progress
+- updated_at: 2026-04-26 Asia/Seoul
+
+## 배경
+- 백엔드가 Lambda 기반으로 전환되면서 애플리케이션 내부 `@Scheduled` 작업을 안정적으로 실행하기 어렵다.
+- 오래 `RUNNING` 상태에 머문 scrape job 정리와 만료 refresh token cleanup은 외부 durable trigger가 실행하는 구조가 더 적합하다.
+
+## 변경 내용
+- `modules/backend_serverless`에 `maintenance_schedules` 입력을 추가한다.
+- 활성화 시 EventBridge Scheduler schedule 2개를 생성한다.
+  - `SCRAPE_JOB_RECONCILE_STALE`: `rate(1 minute)`
+  - `REFRESH_TOKEN_CLEANUP`: `rate(1 hour)`
+- 백엔드 maintenance handler 배포 후 Scheduler state를 `ENABLED`로 전환했다.
+- Scheduler target은 API Gateway가 아니라 backend Lambda `live` alias를 직접 invoke한다.
+- Scheduler execution role은 backend Lambda alias invoke와 Scheduler DLQ `sqs:SendMessage`만 허용한다.
+- Lambda resource policy는 schedule별 `source_arn`으로 invoke permission을 제한한다.
+- Scheduler payload의 `scheduled_at`은 EventBridge Scheduler context attribute `<aws.scheduler.scheduled-time>`을 사용한다.
+- Lambda 환경변수에는 `SCRAPING_SCHEDULER_ENABLED=false`를 명시한다.
+- develop-shadow 원격 state에 이미 존재하는 scrape result S3 리소스가 현재 브랜치에서 삭제 계획으로 잡히지 않도록 `scrape_result_storage` 정의와 backend/worker 환경변수 주입도 함께 복원한다.
+
+## 검증 기준
+- `terraform fmt -recursive`
+- `terraform validate`
+- `terraform plan -var-file=tfvars/develop-shadow.tfvars`
+- plan에서 Scheduler 2개, Scheduler IAM role/policy, Scheduler DLQ, Lambda permission 2개가 추가되고 Scheduler state가 `ENABLED`인지 확인한다.
+- plan에서 scrape result S3 bucket/정책 삭제, worker task definition 교체, Lambda memory/reserved concurrency 되돌림이 발생하지 않는지 확인한다.
+- Lambda 환경변수에 `SCRAPING_SCHEDULER_ENABLED=false`가 유지되는지 확인한다.
+
+## 롤백
+- `backend_serverless.maintenance_schedules.enabled=false`로 되돌리고 Terraform apply 한다.
+- Scheduler, Scheduler role/policy, Scheduler DLQ, Scheduler invoke permission이 제거되는지 plan으로 확인한다.

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,7 @@ module "backend_serverless" {
   certificate_arn                   = var.backend_serverless.certificate_arn
   provisioned_concurrency           = var.backend_serverless.provisioned_concurrency
   create_async_queue                = var.backend_serverless.create_async_queue
+  maintenance_schedules             = var.backend_serverless.maintenance_schedules
   grafana_cloud                     = var.backend_serverless.grafana_cloud
 }
 

--- a/modules/backend_serverless/main.tf
+++ b/modules/backend_serverless/main.tf
@@ -13,9 +13,27 @@ locals {
   async_queue_visibility_secs   = 120
   async_queue_retention_secs    = 345600
   async_queue_max_receive       = 5
+  maintenance_schedules_enabled = var.maintenance_schedules.enabled
+  maintenance_schedule_tasks = {
+    scrape_job_reconcile_stale = {
+      name                = "${var.environment}-${var.app_name}-scrape-job-stale-reconcile"
+      description         = "Invoke backend maintenance task to fail stale scrape jobs."
+      task                = "SCRAPE_JOB_RECONCILE_STALE"
+      schedule_expression = var.maintenance_schedules.stale_scrape_jobs_schedule
+    }
+    refresh_token_cleanup = {
+      name                = "${var.environment}-${var.app_name}-refresh-token-cleanup"
+      description         = "Invoke backend maintenance task to delete expired refresh tokens."
+      task                = "REFRESH_TOKEN_CLEANUP"
+      schedule_expression = var.maintenance_schedules.refresh_token_cleanup_schedule
+    }
+  }
   scraping_callback_hmac_secret = trimspace(var.scraping_callback_hmac_secret_arn) != "" ? nonsensitive(data.aws_secretsmanager_secret_version.scraping_callback_hmac_secret[0].secret_string) : null
   lambda_environment = merge(
     var.lambda_environment,
+    local.maintenance_schedules_enabled ? {
+      SCRAPING_SCHEDULER_ENABLED = "false"
+    } : {},
     trimspace(var.scraping_job_queue_url) != "" ? {
       SCRAPING_JOB_QUEUE_URL = var.scraping_job_queue_url
     } : {},
@@ -305,6 +323,120 @@ resource "aws_lambda_permission" "apigw_invoke" {
   qualifier     = aws_lambda_alias.live.name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*"
+}
+
+resource "aws_sqs_queue" "maintenance_scheduler_dlq" {
+  count = local.maintenance_schedules_enabled ? 1 : 0
+
+  name                      = "${var.environment}-${var.app_name}-maintenance-scheduler-dlq"
+  message_retention_seconds = var.maintenance_schedules.dlq_message_retention_seconds
+
+  tags = {
+    Environment = var.environment
+  }
+}
+
+data "aws_iam_policy_document" "maintenance_scheduler_assume_role" {
+  count = local.maintenance_schedules_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["scheduler.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "maintenance_scheduler" {
+  count = local.maintenance_schedules_enabled ? 1 : 0
+
+  name               = "${var.environment}-${var.app_name}-maintenance-scheduler-role"
+  assume_role_policy = data.aws_iam_policy_document.maintenance_scheduler_assume_role[0].json
+
+  tags = {
+    Environment = var.environment
+  }
+}
+
+data "aws_iam_policy_document" "maintenance_scheduler_invoke" {
+  count = local.maintenance_schedules_enabled ? 1 : 0
+
+  statement {
+    sid    = "AllowBackendLambdaInvoke"
+    effect = "Allow"
+    actions = [
+      "lambda:InvokeFunction"
+    ]
+    resources = [
+      aws_lambda_alias.live.arn
+    ]
+  }
+
+  statement {
+    sid    = "AllowSchedulerDlqSend"
+    effect = "Allow"
+    actions = [
+      "sqs:SendMessage"
+    ]
+    resources = [
+      aws_sqs_queue.maintenance_scheduler_dlq[0].arn
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "maintenance_scheduler_invoke" {
+  count = local.maintenance_schedules_enabled ? 1 : 0
+
+  name   = "${var.environment}-${var.app_name}-maintenance-scheduler-invoke"
+  role   = aws_iam_role.maintenance_scheduler[0].id
+  policy = data.aws_iam_policy_document.maintenance_scheduler_invoke[0].json
+}
+
+resource "aws_scheduler_schedule" "maintenance" {
+  for_each = local.maintenance_schedules_enabled ? local.maintenance_schedule_tasks : {}
+
+  name                = each.value.name
+  description         = each.value.description
+  schedule_expression = each.value.schedule_expression
+  state               = var.maintenance_schedules.state
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = aws_lambda_alias.live.arn
+    role_arn = aws_iam_role.maintenance_scheduler[0].arn
+    input = jsonencode({
+      source       = "eventbridge.scheduler"
+      task         = each.value.task
+      scheduled_at = "<aws.scheduler.scheduled-time>"
+    })
+
+    dead_letter_config {
+      arn = aws_sqs_queue.maintenance_scheduler_dlq[0].arn
+    }
+
+    retry_policy {
+      maximum_event_age_in_seconds = var.maintenance_schedules.maximum_event_age_in_seconds
+      maximum_retry_attempts       = var.maintenance_schedules.maximum_retry_attempts
+    }
+  }
+}
+
+resource "aws_lambda_permission" "maintenance_scheduler_invoke" {
+  for_each = aws_scheduler_schedule.maintenance
+
+  statement_id  = "AllowSchedulerInvoke-${each.key}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.backend.function_name
+  qualifier     = aws_lambda_alias.live.name
+  principal     = "scheduler.amazonaws.com"
+  source_arn    = each.value.arn
 }
 
 resource "aws_sqs_queue" "async_dlq" {

--- a/modules/backend_serverless/outputs.tf
+++ b/modules/backend_serverless/outputs.tf
@@ -29,3 +29,11 @@ output "async_queue_url" {
 output "lambda_role_arn" {
   value = aws_iam_role.lambda_exec.arn
 }
+
+output "maintenance_scheduler_names" {
+  value = var.maintenance_schedules.enabled ? [for schedule in aws_scheduler_schedule.maintenance : schedule.name] : []
+}
+
+output "maintenance_scheduler_dlq_arn" {
+  value = var.maintenance_schedules.enabled ? aws_sqs_queue.maintenance_scheduler_dlq[0].arn : null
+}

--- a/modules/backend_serverless/variables.tf
+++ b/modules/backend_serverless/variables.tf
@@ -61,6 +61,39 @@ variable "create_async_queue" {
   default = false
 }
 
+variable "maintenance_schedules" {
+  type = object({
+    enabled                        = bool
+    state                          = string
+    stale_scrape_jobs_schedule     = string
+    refresh_token_cleanup_schedule = string
+    maximum_retry_attempts         = number
+    maximum_event_age_in_seconds   = number
+    dlq_message_retention_seconds  = number
+  })
+  default = {
+    enabled                        = false
+    state                          = "DISABLED"
+    stale_scrape_jobs_schedule     = "rate(5 minutes)"
+    refresh_token_cleanup_schedule = "rate(1 hour)"
+    maximum_retry_attempts         = 3
+    maximum_event_age_in_seconds   = 300
+    dlq_message_retention_seconds  = 1209600
+  }
+
+  validation {
+    condition = !var.maintenance_schedules.enabled || (
+      trimspace(var.maintenance_schedules.stale_scrape_jobs_schedule) != "" &&
+      trimspace(var.maintenance_schedules.refresh_token_cleanup_schedule) != "" &&
+      contains(["ENABLED", "DISABLED"], var.maintenance_schedules.state) &&
+      var.maintenance_schedules.maximum_retry_attempts >= 0 &&
+      var.maintenance_schedules.maximum_event_age_in_seconds >= 60 &&
+      var.maintenance_schedules.dlq_message_retention_seconds >= 60
+    )
+    error_message = "maintenance_schedules.enabled=true 인 경우 schedule expression은 비어 있을 수 없고 retry/event age/DLQ retention 값은 양수 범위여야 한다."
+  }
+}
+
 variable "grafana_cloud" {
   type = object({
     enabled             = bool

--- a/outputs.tf
+++ b/outputs.tf
@@ -42,6 +42,14 @@ output "backend_serverless_custom_domain_hosted_zone_id" {
   value = var.enable_backend_serverless ? module.backend_serverless[0].custom_domain_hosted_zone_id : null
 }
 
+output "backend_serverless_maintenance_scheduler_names" {
+  value = var.enable_backend_serverless ? module.backend_serverless[0].maintenance_scheduler_names : []
+}
+
+output "backend_serverless_maintenance_scheduler_dlq_arn" {
+  value = var.enable_backend_serverless ? module.backend_serverless[0].maintenance_scheduler_dlq_arn : null
+}
+
 output "scrape_result_bucket_name" {
   value = local.scrape_result_enabled ? local.scrape_result_bucket_name : null
 }

--- a/tfvars/develop-shadow.tfvars.example
+++ b/tfvars/develop-shadow.tfvars.example
@@ -60,6 +60,7 @@ backend_serverless = {
     LOG_PATH                                = "/tmp"
     MANAGEMENT_TRACING_SAMPLING_PROBABILITY = "1.0"
     REDIS_ENCRYPT_KEY                       = "<redis-encrypt-key>"
+    SCRAPING_SCHEDULER_ENABLED              = "false"
     SPRING_PROFILES_ACTIVE                  = "develop-shadow"
   }
   scraping_job_queue_url            = ""
@@ -69,6 +70,15 @@ backend_serverless = {
   certificate_arn                   = "arn:aws:acm:ap-northeast-2:<account_id>:certificate/<certificate-id>"
   provisioned_concurrency           = 0
   create_async_queue                = false
+  maintenance_schedules = {
+    enabled                         = true
+    state                           = "ENABLED"
+    stale_scrape_jobs_schedule      = "rate(1 minute)"
+    refresh_token_cleanup_schedule  = "rate(1 hour)"
+    maximum_retry_attempts          = 3
+    maximum_event_age_in_seconds    = 300
+    dlq_message_retention_seconds   = 1209600
+  }
   grafana_cloud = {
     enabled             = true
     instance_id         = "<grafana-instance-id>"

--- a/variables.tf
+++ b/variables.tf
@@ -178,6 +178,15 @@ variable "backend_serverless" {
     certificate_arn                   = string
     provisioned_concurrency           = number
     create_async_queue                = bool
+    maintenance_schedules = object({
+      enabled                        = bool
+      state                          = string
+      stale_scrape_jobs_schedule     = string
+      refresh_token_cleanup_schedule = string
+      maximum_retry_attempts         = number
+      maximum_event_age_in_seconds   = number
+      dlq_message_retention_seconds  = number
+    })
     grafana_cloud = object({
       enabled             = bool
       instance_id         = string
@@ -200,6 +209,15 @@ variable "backend_serverless" {
     certificate_arn                   = ""
     provisioned_concurrency           = 0
     create_async_queue                = false
+    maintenance_schedules = {
+      enabled                        = false
+      state                          = "DISABLED"
+      stale_scrape_jobs_schedule     = "rate(5 minutes)"
+      refresh_token_cleanup_schedule = "rate(1 hour)"
+      maximum_retry_attempts         = 3
+      maximum_event_age_in_seconds   = 300
+      dlq_message_retention_seconds  = 1209600
+    }
     grafana_cloud = {
       enabled             = false
       instance_id         = ""


### PR DESCRIPTION
## 변경 요약
- Backend Lambda maintenance 작업을 EventBridge Scheduler direct invoke 방식으로 실행할 수 있도록 인프라를 추가했습니다.
- `SCRAPE_JOB_RECONCILE_STALE`, `REFRESH_TOKEN_CLEANUP` 스케줄과 전용 IAM Role, Lambda invoke permission, DLQ를 구성했습니다.
- Lambda 내부 Spring scheduler 비활성화를 위해 `SCRAPING_SCHEDULER_ENABLED=false`를 인프라 환경변수로 명시했습니다.
- develop-shadow 적용 예시 tfvars와 작업 context 문서를 추가했습니다.
- `AGENTS.md`에 maintenance schedule 관리 규칙과 S3 결과 저장소 관리 규칙을 반영했습니다.

## 영향 범위
- 대상 환경: `develop-shadow`
- Backend Lambda: 환경변수 1개 추가 및 maintenance Scheduler direct invoke 권한 추가
- EventBridge Scheduler: 2개 schedule 생성
- SQS: Scheduler 실패 추적용 DLQ 1개 생성
- Scraper 기존 경로(`develop-shadow-scraper-jobs-to-ecs`)는 유지됩니다.

## 롤백 방법
- `backend_serverless.maintenance_schedules.enabled=false`로 변경 후 Terraform plan/apply를 수행하면 Scheduler, invoke permission, Scheduler IAM Role/Policy, DLQ가 제거됩니다.
- 필요 시 `SCRAPING_SCHEDULER_ENABLED` 환경변수는 기존 설정으로 되돌립니다.

## 검증 증적
- `terraform fmt -recursive -check` 성공
- `terraform validate -no-color` 성공
- `terraform plan -var-file=tfvars/develop-shadow.tfvars -no-color` 결과: `No changes`
- 실제 적용 후 확인:
  - 1분 Scheduler `SCRAPE_JOB_RECONCILE_STALE` 실행 로그 확인
  - Lambda live alias invocation 발생, error `0`
  - Scheduler DLQ 메시지 `0`
  - 기존 scraper Pipe `RUNNING`, target task definition `develop-shadow-scraper-worker:13` 유지

## 관련 context 파일
- `docs/eventbridge-maintenance-scheduler-context.md`

## AGENTS.md 업데이트 필요 여부
- 필요함. backend_serverless maintenance schedule 관리 규칙과 scrape result storage 관리 규칙을 반영했습니다.